### PR TITLE
Broken extra assignment link

### DIFF
--- a/week3/homework.md
+++ b/week3/homework.md
@@ -32,7 +32,7 @@ Worth considering:
 
 ## Extra assignment
 
-Make the exercises in [chat-app](/documentation/chat-app/Exercises.md)!
+Make the exercises in [chat-app](/documentation/chat-app/Exercises.md)! 
 
 ## Hand in Homework:
 


### PR DESCRIPTION
The extra assignment link is broken. It routes to a 404

//Make the exercises in [chat-app](/documentation/chat-app/Exercises.md)!